### PR TITLE
webpack now using terser instead of uglify-js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,15 +32,6 @@
                 }
             }
         },
-        "@babel/polyfill": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.0.0.tgz",
-            "integrity": "sha512-dnrMRkyyr74CRelJwvgnnSUDh2ge2NCTyHVwpOdvRMHtJUyxLtMAfhBN3s64pY41zdw0kgiLPh6S20eb1NcX6Q==",
-            "requires": {
-                "core-js": "^2.5.7",
-                "regenerator-runtime": "^0.11.1"
-            }
-        },
         "@sinonjs/commons": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
@@ -980,7 +971,6 @@
             "version": "6.26.0",
             "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
             "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-            "dev": true,
             "requires": {
                 "core-js": "^2.4.0",
                 "regenerator-runtime": "^0.11.0"
@@ -2984,6 +2974,7 @@
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
             "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
+            "dev": true,
             "requires": {
                 "ms": "^2.1.1"
             }
@@ -8359,19 +8350,19 @@
             "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
         },
         "knex": {
-            "version": "0.16.0",
-            "resolved": "https://registry.npmjs.org/knex/-/knex-0.16.0.tgz",
-            "integrity": "sha512-+TiL02P00GEmdwpKRfgOaRGaI29KeTcvAT7os1jeWMPMnzu8g/C3O4CZ1LXtLo5V1oatUzJcPKBqWATPgS20ng==",
+            "version": "0.15.2",
+            "resolved": "https://registry.npmjs.org/knex/-/knex-0.15.2.tgz",
+            "integrity": "sha1-YFm4dIlgX0zIdZmm0qnSZXCek0A=",
             "requires": {
-                "@babel/polyfill": "^7.0.0",
-                "bluebird": "^3.5.3",
-                "chalk": "2.4.1",
-                "commander": "^2.19.0",
-                "debug": "4.1.0",
+                "babel-runtime": "^6.26.0",
+                "bluebird": "^3.5.1",
+                "chalk": "2.3.2",
+                "commander": "^2.16.0",
+                "debug": "3.1.0",
                 "inherits": "~2.0.3",
                 "interpret": "^1.1.0",
                 "liftoff": "2.5.0",
-                "lodash": "^4.17.11",
+                "lodash": "^4.17.10",
                 "minimist": "1.2.0",
                 "mkdirp": "^0.5.1",
                 "pg-connection-string": "2.0.0",
@@ -8381,15 +8372,33 @@
                 "v8flags": "^3.1.1"
             },
             "dependencies": {
-                "commander": {
-                    "version": "2.19.0",
-                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-                    "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+                "chalk": {
+                    "version": "2.3.2",
+                    "resolved": "http://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+                    "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
                 },
                 "minimist": {
                     "version": "1.2.0",
                     "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                     "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -13679,9 +13679,9 @@
             }
         },
         "terser": {
-            "version": "3.10.12",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-3.10.12.tgz",
-            "integrity": "sha512-3ODPC1eVt25EVNb04s/PkHxOmzKBQUF6bwwuR6h2DbEF8/j265Y1UkwNtOk9am/pRxfJ5HPapOlUlO6c16mKQQ==",
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-3.11.0.tgz",
+            "integrity": "sha512-5iLMdhEPIq3zFWskpmbzmKwMQixKmTYwY3Ox9pjtSklBLnHiuQ0GKJLhL1HSYtyffHM3/lDIFBnb82m9D7ewwQ==",
             "dev": true,
             "requires": {
                 "commander": "~2.17.1",
@@ -14069,84 +14069,6 @@
             "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
             "dev": true,
             "optional": true
-        },
-        "uglifyjs-webpack-plugin": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-2.0.1.tgz",
-            "integrity": "sha512-1HhCHkOB6wRCcv7htcz1QRPVbWPEY074RP9vzt/X0LF4xXm9l4YGd0qja7z88abDixQlnVwBjXsTBs+Xsn/eeQ==",
-            "dev": true,
-            "requires": {
-                "cacache": "^11.2.0",
-                "find-cache-dir": "^2.0.0",
-                "schema-utils": "^1.0.0",
-                "serialize-javascript": "^1.4.0",
-                "source-map": "^0.6.1",
-                "uglify-js": "^3.0.0",
-                "webpack-sources": "^1.1.0",
-                "worker-farm": "^1.5.2"
-            },
-            "dependencies": {
-                "cacache": {
-                    "version": "11.3.1",
-                    "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.1.tgz",
-                    "integrity": "sha512-2PEw4cRRDu+iQvBTTuttQifacYjLPhET+SYO/gEFMy8uhi+jlJREDAjSF5FWSdV/Aw5h18caHA7vMTw2c+wDzA==",
-                    "dev": true,
-                    "requires": {
-                        "bluebird": "^3.5.1",
-                        "chownr": "^1.0.1",
-                        "figgy-pudding": "^3.1.0",
-                        "glob": "^7.1.2",
-                        "graceful-fs": "^4.1.11",
-                        "lru-cache": "^4.1.3",
-                        "mississippi": "^3.0.0",
-                        "mkdirp": "^0.5.1",
-                        "move-concurrently": "^1.0.1",
-                        "promise-inflight": "^1.0.1",
-                        "rimraf": "^2.6.2",
-                        "ssri": "^6.0.0",
-                        "unique-filename": "^1.1.0",
-                        "y18n": "^4.0.0"
-                    }
-                },
-                "find-cache-dir": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.0.0.tgz",
-                    "integrity": "sha512-LDUY6V1Xs5eFskUVYtIwatojt6+9xC9Chnlk/jYOOvn3FAFfSaWddxahDGyNHh0b2dMXa6YW2m0tk8TdVaXHlA==",
-                    "dev": true,
-                    "requires": {
-                        "commondir": "^1.0.1",
-                        "make-dir": "^1.0.0",
-                        "pkg-dir": "^3.0.0"
-                    }
-                },
-                "mississippi": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/mississippi/-/mississippi-3.0.0.tgz",
-                    "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
-                    "dev": true,
-                    "requires": {
-                        "concat-stream": "^1.5.0",
-                        "duplexify": "^3.4.2",
-                        "end-of-stream": "^1.1.0",
-                        "flush-write-stream": "^1.0.0",
-                        "from2": "^2.1.0",
-                        "parallel-transform": "^1.1.0",
-                        "pump": "^3.0.0",
-                        "pumpify": "^1.3.3",
-                        "stream-each": "^1.1.0",
-                        "through2": "^2.0.0"
-                    }
-                },
-                "ssri": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-                    "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
-                    "dev": true,
-                    "requires": {
-                        "figgy-pudding": "^3.5.1"
-                    }
-                }
-            }
         },
         "unc-path-regex": {
             "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
         "inert": "^5.1.2",
         "joi": "^14.3.0",
         "jsonwebtoken": "^8.4.0",
-        "knex": "^0.16.0",
+        "knex": "^0.15.2",
         "lout": "^11.1.0",
         "nodemailer": "^4.7.0",
         "objection": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
         "simple-progress-webpack-plugin": "^1.1.2",
         "sinon": "^7.1.1",
         "style-loader": "^0.23.1",
-        "uglifyjs-webpack-plugin": "^2.0.1",
+        "terser-webpack-plugin": "^1.1.0",
         "url-loader": "^1.1.2",
         "webpack": "4.26.1",
         "webpack-merge": "^4.1.4"

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -1,7 +1,7 @@
 const path = require('path');
 const merge = require('webpack-merge');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
-const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const OptimizeCSSAssetsPlugin = require('optimize-css-assets-webpack-plugin');
 const htmlMinifier = require('html-minifier');
 const common = require('./webpack.common.js');
@@ -48,11 +48,11 @@ module.exports = merge(common, {
     mode: 'production',
     optimization: {
         minimizer: [
-            new UglifyJsPlugin({
+            new TerserPlugin({
                 cache: true,
                 parallel: true,
                 sourceMap: false,
-                uglifyOptions: {
+                terserOptions: {
                     compress: {
                         ie8: false,
                         unused: true,


### PR DESCRIPTION
The current build process is failing due to UglifyJS not supporting ES6+.

The change was made so that our production configuration file for Webpack is now using `terser-webpack-plugin` instead of `uglifyjs-webpack-plugin`, which is causing the current error during our build process.

Edit: `knex` version was also reverted to `0.15.2` since `0.16.0` is not yet available on npm.