### PR TITLE
Add Permission Endpoint, fix issue with service delete tests, remove boolean handling in user service tests

### DIFF
--- a/db/seeds/development/02_authorization.js
+++ b/db/seeds/development/02_authorization.js
@@ -14,6 +14,11 @@ exports.seed = function(knex, Promise) {
             id: 3,
             name: 'contact',
             description: 'Contacts Management'
+        }),
+        knex('resources').insert({
+            id: 4,
+            name: 'permissions',
+            description: 'System Permissions'
         })
     ])
         .then(() => {
@@ -95,6 +100,36 @@ exports.seed = function(knex, Promise) {
                     action: 'list',
                     resource_id: 3,
                     description: 'List contacts'
+                }),
+                knex('permissions').insert({
+                    id: 14,
+                    action: 'read',
+                    resource_id: 3,
+                    description: 'Fetch a permission'
+                }),
+                knex('permissions').insert({
+                    id: 15,
+                    action: 'list',
+                    resource_id: 3,
+                    description: 'Lists permissions'
+                }),
+                knex('permissions').insert({
+                    id: 16,
+                    action: 'update',
+                    resource_id: 3,
+                    description: 'Update an existing permissions'
+                }),
+                knex('permissions').insert({
+                    id: 17,
+                    action: 'create',
+                    resource_id: 3,
+                    description: 'Create a new permissions'
+                }),
+                knex('permissions').insert({
+                    id: 18,
+                    action: 'delete',
+                    resource_id: 3,
+                    description: 'Delete a permission'
                 })
             ]);
         })
@@ -139,6 +174,30 @@ exports.seed = function(knex, Promise) {
                 knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 10
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 13
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 14
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 15
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 16
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 17
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 18
                 }),
                 knex('roles_permissions').insert({
                     role_id: 2,

--- a/db/seeds/development/02_authorization.js
+++ b/db/seeds/development/02_authorization.js
@@ -17,7 +17,7 @@ exports.seed = function(knex, Promise) {
         }),
         knex('resources').insert({
             id: 4,
-            name: 'permissions',
+            name: 'permission',
             description: 'System Permissions'
         })
     ])
@@ -69,13 +69,13 @@ exports.seed = function(knex, Promise) {
                     id: 8,
                     action: 'update',
                     resource_id: 2,
-                    description: 'Update an existing role, add users and permissions'
+                    description: 'Update an existing role, add users and permission'
                 }),
                 knex('permissions').insert({
                     id: 9,
                     action: 'delete',
                     resource_id: 2,
-                    description: 'Delete a role, remove users and permissions'
+                    description: 'Delete a role, remove users and permission'
                 }),
                 knex('permissions').insert({
                     id: 10,
@@ -104,31 +104,31 @@ exports.seed = function(knex, Promise) {
                 knex('permissions').insert({
                     id: 14,
                     action: 'read',
-                    resource_id: 3,
+                    resource_id: 4,
                     description: 'Fetch a permission'
                 }),
                 knex('permissions').insert({
                     id: 15,
                     action: 'list',
-                    resource_id: 3,
-                    description: 'Lists permissions'
+                    resource_id: 4,
+                    description: 'Lists permission'
                 }),
                 knex('permissions').insert({
                     id: 16,
                     action: 'update',
-                    resource_id: 3,
-                    description: 'Update an existing permissions'
+                    resource_id: 4,
+                    description: 'Update an existing permission'
                 }),
                 knex('permissions').insert({
                     id: 17,
                     action: 'create',
-                    resource_id: 3,
-                    description: 'Create a new permissions'
+                    resource_id: 4,
+                    description: 'Create a new permission'
                 }),
                 knex('permissions').insert({
                     id: 18,
                     action: 'delete',
-                    resource_id: 3,
+                    resource_id: 4,
                     description: 'Delete a permission'
                 })
             ]);

--- a/db/seeds/development/02_authorization.js
+++ b/db/seeds/development/02_authorization.js
@@ -69,13 +69,13 @@ exports.seed = function(knex, Promise) {
                     id: 8,
                     action: 'update',
                     resource_id: 2,
-                    description: 'Update an existing role, add users and permission'
+                    description: 'Update an existing role, add users and permissions'
                 }),
                 knex('permissions').insert({
                     id: 9,
                     action: 'delete',
                     resource_id: 2,
-                    description: 'Delete a role, remove users and permission'
+                    description: 'Delete a role, remove users and permissions'
                 }),
                 knex('permissions').insert({
                     id: 10,

--- a/db/seeds/staging/02_authorization.js
+++ b/db/seeds/staging/02_authorization.js
@@ -14,6 +14,11 @@ exports.seed = function(knex, Promise) {
             id: 3,
             name: 'contact',
             description: 'Contacts Management'
+        }),
+        knex('resources').insert({
+            id: 4,
+            name: 'permissions',
+            description: 'System Permissions'
         })
     ])
         .then(() => {
@@ -95,6 +100,36 @@ exports.seed = function(knex, Promise) {
                     action: 'list',
                     resource_id: 3,
                     description: 'List contacts'
+                }),
+                knex('permissions').insert({
+                    id: 14,
+                    action: 'read',
+                    resource_id: 3,
+                    description: 'Fetch a permission'
+                }),
+                knex('permissions').insert({
+                    id: 15,
+                    action: 'list',
+                    resource_id: 3,
+                    description: 'Lists permissions'
+                }),
+                knex('permissions').insert({
+                    id: 16,
+                    action: 'update',
+                    resource_id: 3,
+                    description: 'Update an existing permissions'
+                }),
+                knex('permissions').insert({
+                    id: 17,
+                    action: 'create',
+                    resource_id: 3,
+                    description: 'Create a new permissions'
+                }),
+                knex('permissions').insert({
+                    id: 18,
+                    action: 'delete',
+                    resource_id: 3,
+                    description: 'Delete a permission'
                 })
             ]);
         })
@@ -139,6 +174,30 @@ exports.seed = function(knex, Promise) {
                 knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 10
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 13
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 14
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 15
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 16
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 17
+                }),
+                knex('roles_permissions').insert({
+                    role_id: 1,
+                    permission_id: 18
                 }),
                 knex('roles_permissions').insert({
                     role_id: 2,

--- a/db/seeds/staging/02_authorization.js
+++ b/db/seeds/staging/02_authorization.js
@@ -17,193 +17,193 @@ exports.seed = function(knex, Promise) {
         }),
         knex('resources').insert({
             id: 4,
-            name: 'permissions',
+            name: 'permission',
             description: 'System Permissions'
         })
     ])
         .then(() => {
             return Promise.all([
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 1,
                     action: 'create',
                     resource_id: 1,
                     description: 'Create a new user'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 2,
                     action: 'read',
                     resource_id: 1,
                     description: 'Fetch a user'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 3,
                     action: 'update',
                     resource_id: 1,
                     description: 'Update an existing user'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 4,
                     action: 'delete',
                     resource_id: 1,
                     description: 'Delete a user'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 5,
                     action: 'list',
                     resource_id: 1,
                     description: 'List users'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 6,
                     action: 'create',
                     resource_id: 2,
                     description: 'Create a new role'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 7,
                     action: 'read',
                     resource_id: 2,
                     description: 'Fetch a role'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 8,
                     action: 'update',
                     resource_id: 2,
-                    description: 'Update an existing role, add users and permissions'
+                    description: 'Update an existing role, add users and permission'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 9,
                     action: 'delete',
                     resource_id: 2,
-                    description: 'Delete a role, remove users and permissions'
+                    description: 'Delete a role, remove users and permission'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 10,
                     action: 'list',
                     resource_id: 2,
                     description: 'List roles'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 11,
                     action: 'read',
                     resource_id: 3,
                     description: 'Fetch a contact'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 12,
                     action: 'delete',
                     resource_id: 3,
                     description: 'Delete a contact'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 13,
                     action: 'list',
                     resource_id: 3,
                     description: 'List contacts'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 14,
                     action: 'read',
-                    resource_id: 3,
+                    resource_id: 4,
                     description: 'Fetch a permission'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 15,
                     action: 'list',
-                    resource_id: 3,
-                    description: 'Lists permissions'
+                    resource_id: 4,
+                    description: 'Lists permission'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 16,
                     action: 'update',
-                    resource_id: 3,
-                    description: 'Update an existing permissions'
+                    resource_id: 4,
+                    description: 'Update an existing permission'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 17,
                     action: 'create',
-                    resource_id: 3,
-                    description: 'Create a new permissions'
+                    resource_id: 4,
+                    description: 'Create a new permission'
                 }),
-                knex('permissions').insert({
+                knex('permission').insert({
                     id: 18,
                     action: 'delete',
-                    resource_id: 3,
+                    resource_id: 4,
                     description: 'Delete a permission'
                 })
             ]);
         })
         .then(() => {
             return Promise.all([
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 1
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 2
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 3
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 4
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 5
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 6
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 7
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 8
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 9
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 10
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 13
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 14
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 15
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 16
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 17
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 1,
                     permission_id: 18
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 2,
                     permission_id: 2
                 }),
-                knex('roles_permissions').insert({
+                knex('roles_permission').insert({
                     role_id: 2,
                     permission_id: 7
                 })

--- a/db/seeds/staging/02_authorization.js
+++ b/db/seeds/staging/02_authorization.js
@@ -23,109 +23,109 @@ exports.seed = function(knex, Promise) {
     ])
         .then(() => {
             return Promise.all([
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 1,
                     action: 'create',
                     resource_id: 1,
                     description: 'Create a new user'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 2,
                     action: 'read',
                     resource_id: 1,
                     description: 'Fetch a user'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 3,
                     action: 'update',
                     resource_id: 1,
                     description: 'Update an existing user'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 4,
                     action: 'delete',
                     resource_id: 1,
                     description: 'Delete a user'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 5,
                     action: 'list',
                     resource_id: 1,
                     description: 'List users'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 6,
                     action: 'create',
                     resource_id: 2,
                     description: 'Create a new role'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 7,
                     action: 'read',
                     resource_id: 2,
                     description: 'Fetch a role'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 8,
                     action: 'update',
                     resource_id: 2,
-                    description: 'Update an existing role, add users and permission'
+                    description: 'Update an existing role, add users and permissions'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 9,
                     action: 'delete',
                     resource_id: 2,
-                    description: 'Delete a role, remove users and permission'
+                    description: 'Delete a role, remove users and permissions'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 10,
                     action: 'list',
                     resource_id: 2,
                     description: 'List roles'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 11,
                     action: 'read',
                     resource_id: 3,
                     description: 'Fetch a contact'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 12,
                     action: 'delete',
                     resource_id: 3,
                     description: 'Delete a contact'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 13,
                     action: 'list',
                     resource_id: 3,
                     description: 'List contacts'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 14,
                     action: 'read',
                     resource_id: 4,
                     description: 'Fetch a permission'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 15,
                     action: 'list',
                     resource_id: 4,
-                    description: 'Lists permission'
+                    description: 'Lists permissions'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 16,
                     action: 'update',
                     resource_id: 4,
                     description: 'Update an existing permission'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 17,
                     action: 'create',
                     resource_id: 4,
                     description: 'Create a new permission'
                 }),
-                knex('permission').insert({
+                knex('permissions').insert({
                     id: 18,
                     action: 'delete',
                     resource_id: 4,
@@ -135,75 +135,75 @@ exports.seed = function(knex, Promise) {
         })
         .then(() => {
             return Promise.all([
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 1
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 2
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 3
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 4
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 5
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 6
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 7
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 8
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 9
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 10
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 13
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 14
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 15
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 16
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 17
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 1,
                     permission_id: 18
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 2,
                     permission_id: 2
                 }),
-                knex('roles_permission').insert({
+                knex('roles_permissions').insert({
                     role_id: 2,
                     permission_id: 7
                 })

--- a/db/seeds/testing/authorization.js
+++ b/db/seeds/testing/authorization.js
@@ -49,6 +49,12 @@ exports.seed = function(knex, Promise) {
                         action: 'read',
                         resource_id: 4,
                         description: 'Should not change'
+                    }),
+                    knex('permissions').insert({
+                        id: 10,
+                        action: 'delete',
+                        resource_id: 5,
+                        description: 'Should not change'
                     })
                 ]);
             }),
@@ -73,6 +79,21 @@ exports.seed = function(knex, Promise) {
                     knex('resources').insert({
                         id: 4,
                         name: 'noroles'
+                    }),
+                    knex('resources').insert({
+                        id: 5,
+                        name: 'contact',
+                        description: 'contact description'
+                    }),
+                    knex('resources').insert({
+                        id: 6,
+                        name: 'permission',
+                        description: 'permission description'
+                    }),
+                    knex('resources').insert({
+                        id: 7,
+                        name: 'no test',
+                        description: 'description'
                     })
                 ]);
             }),

--- a/lib/config/dev.js
+++ b/lib/config/dev.js
@@ -7,7 +7,7 @@ exports.connections = {
     api: {
         host: process.env.API_HOST || 'localhost',
         port: process.env.API_PORT || 8081,
-        tls: true,
+        tls: false,
         enabled: true,
         cors: ['*']
     },

--- a/lib/enums/resources.js
+++ b/lib/enums/resources.js
@@ -11,7 +11,8 @@ const internals = {};
 internals.resources = {
     CONTACT: 'contact',
     USER: 'user',
-    ROLE: 'role'
+    ROLE: 'role',
+    PERMISSION: 'permission'
 };
 
 module.exports = internals.resources;

--- a/lib/models/permission.js
+++ b/lib/models/permission.js
@@ -23,6 +23,17 @@ class Permission extends BaseModel {
     }
 
     /**
+     * Get the model properties to perform search on
+     * @readonly
+     * @static
+     * @memberof Permission
+     * @returns {Array.<string>} the model properties
+     */
+    static get searchFields() {
+        return ['description', 'action'];
+    }
+
+    /**
      * Get the model properties to hide when converting to JSON
      * @readonly
      * @static

--- a/lib/modules/authorization/controllers/api/permission.js
+++ b/lib/modules/authorization/controllers/api/permission.js
@@ -1,0 +1,70 @@
+/**
+ * API Permission Controller
+ * @module
+ */
+
+const PermissionService = require('modules/authorization/services/permission');
+
+/**
+ * Lists permissions
+ * @param {Request} request the request object
+ * @param {Toolkit} h the response toolkit
+ * @returns {Response} the response object containing the list of roles
+ */
+exports.list = async function(request, h) {
+    const [totalCount, results] = await Promise.all([
+        PermissionService.count(request.query),
+        PermissionService.list(request.query)
+    ]);
+
+    return h.paginate(results, totalCount);
+};
+
+/**
+ * Gets a permission
+ * @param {Request} request the request object
+ * @param {Toolkit} h the response toolkit
+ * @returns {Response} the response object containing the role
+ */
+exports.get = function(request) {
+    // path params are passed as strings
+    const id = Number.parseInt(request.params.id);
+
+    return PermissionService.findById(id);
+};
+
+/**
+ * Creates a new permission
+ * @param {Request} request the request object
+ * @param {Toolkit} h the response toolkit
+ * @returns {Response} the response object containing the created role
+ */
+exports.create = async function(request, h) {
+    const data = await PermissionService.add(request.payload);
+
+    return h.response(data).created(`/permission/${data.id}`);
+};
+
+/**
+ * Deletes a permission
+ * @param {Request} request the request object
+ * @param {Toolkit} h the response toolkit
+ * @returns {Response} the response object
+ */
+exports.delete = async function(request, h) {
+    await PermissionService.delete(request.params.id);
+
+    return h.response().code(204);
+};
+
+/**
+ * Update a permission
+ * @param {Request} request the request object
+ * @param {Toolkit} h the response toolkit
+ * @returns {Response} the response object containing the updated user
+ */
+exports.update = function(request) {
+    const [id, payload] = [Number.parseInt(request.params.id), request.payload];
+
+    return PermissionService.update(id, payload);
+};

--- a/lib/modules/authorization/controllers/api/resource.js
+++ b/lib/modules/authorization/controllers/api/resource.js
@@ -12,3 +12,12 @@ const ResourceService = require('modules/authorization/services/resource');
 exports.list = function() {
     return ResourceService.list();
 };
+
+/**
+ * Gets resource by name
+ * @param {Request} request the request object
+ * @returns {Response} the response object containing the list of resources
+ */
+exports.getByName = function(request) {
+    return ResourceService.findByName(request.params.name);
+};

--- a/lib/modules/authorization/routes/api/permission.js
+++ b/lib/modules/authorization/routes/api/permission.js
@@ -1,0 +1,113 @@
+/**
+ * Api permission routes
+ */
+const Joi = require('joi');
+const AuthCtrl = require('modules/authorization/controllers/authorization');
+const PermissionCtrl = require('modules/authorization/controllers/api/permission');
+const Permission = require('models/permission');
+const Resource = require('models/resource');
+const Resources = require('enums/resources');
+const Actions = require('enums/actions');
+
+// GET /permission
+exports.list = {
+    description: 'List available permissions',
+    pre: [AuthCtrl.authorize(Resources.PERMISSION, Actions.LIST)],
+    handler: PermissionCtrl.list,
+    validate: {
+        query: {
+            limit: Joi.number()
+                .integer()
+                .min(1)
+                .max(100)
+                .description('The limit of permissions to get'),
+            page: Joi.number()
+                .integer()
+                .positive()
+                .description('The page to get the permissions from'),
+            search: Joi.string().description('The search criteria'),
+            sort: Joi.string().description('The sorting order')
+        }
+    }
+};
+
+// GET /permission/{id}
+exports.get = {
+    description: 'Get permission by ID',
+    pre: [AuthCtrl.authorize(Resources.PERMISSION)],
+    handler: PermissionCtrl.get,
+    validate: {
+        params: {
+            id: Joi.number()
+                .integer()
+                .positive()
+                .required()
+                .description('The ID of the permission')
+        }
+    }
+};
+
+// POST /permission
+exports.create = {
+    description: 'Adds a new permission',
+    pre: [AuthCtrl.authorize(Resources.PERMISSION)],
+    handler: PermissionCtrl.create,
+    validate: {
+        payload: {
+            action: Joi.string()
+                .valid(Object.values(Actions))
+                .required()
+                .description('The action associated with the permission'),
+            resource: Joi.string()
+                .min(Resource.NAME_MIN_LENGTH)
+                .max(Resource.NAME_MAX_LENGTH)
+                .required()
+                .description('The resource the permission refers to'),
+            description: Joi.string()
+                .max(Permission.DESCRIPTION_MAX_LENGTH)
+                .required()
+                .description('The description of the permission')
+        }
+    }
+};
+
+// DELETE /permission/{id}
+exports.delete = {
+    description: 'Delete an existing permission',
+    pre: [AuthCtrl.authorize(Resources.PERMISSION)],
+    handler: PermissionCtrl.delete,
+    validate: {
+        params: {
+            id: Joi.number()
+                .integer()
+                .positive()
+                .required()
+                .description('The ID of the permission')
+        }
+    }
+};
+
+// PUT /permission/{id}
+exports.update = {
+    description: 'Update an existing permission',
+    pre: [AuthCtrl.authorize(Resources.PERMISSION)],
+    handler: PermissionCtrl.update,
+    validate: {
+        params: {
+            id: Joi.number()
+                .integer()
+                .positive()
+                .required()
+                .description('The id of the permission')
+        },
+        payload: {
+            id: Joi.forbidden(),
+            action: Joi.forbidden(),
+            resource: Joi.forbidden(),
+            description: Joi.string()
+                .max(Permission.DESCRIPTION_MAX_LENGTH)
+                .required()
+                .description('The description of the permission')
+        }
+    }
+};

--- a/lib/modules/authorization/routes/api/resource.js
+++ b/lib/modules/authorization/routes/api/resource.js
@@ -2,6 +2,7 @@
  * Api resource routes
  */
 
+const Joi = require('joi');
 const AuthCtrl = require('modules/authorization/controllers/authorization');
 const ResourceCtrl = require('modules/authorization/controllers/api/resource');
 const Resources = require('enums/resources');
@@ -12,4 +13,18 @@ exports.list = {
     description: 'Lists all resources and permissions in the system',
     pre: [AuthCtrl.authorize(Resources.ROLE, Actions.LIST)],
     handler: ResourceCtrl.list
+};
+
+// GET /resource/{name}
+exports.get = {
+    description: 'Gets a resource by name',
+    pre: [AuthCtrl.authorize(Resources.PERMISSION)],
+    handler: ResourceCtrl.getByName,
+    validate: {
+        params: {
+            name: Joi.string()
+                .required()
+                .description('The name of the resource')
+        }
+    }
 };

--- a/lib/modules/authorization/routes/api/role.js
+++ b/lib/modules/authorization/routes/api/role.js
@@ -8,7 +8,6 @@ const Permission = require('models/permission');
 const Role = require('models/role');
 const Resource = require('models/resource');
 const Resources = require('enums/resources');
-const Actions = require('enums/actions');
 
 // GET /role
 exports.list = {

--- a/lib/modules/authorization/routes/api/role.js
+++ b/lib/modules/authorization/routes/api/role.js
@@ -8,11 +8,12 @@ const Permission = require('models/permission');
 const Role = require('models/role');
 const Resource = require('models/resource');
 const Resources = require('enums/resources');
+const Actions = require('enums/actions');
 
 // GET /role
 exports.list = {
     description: 'Lists available roles',
-    pre: [AuthCtrl.authorize(Resources.ROLE)],
+    pre: [AuthCtrl.authorize(Resources.ROLE, Actions.LIST)],
     handler: RoleCtrl.list,
     validate: {
         query: {

--- a/lib/modules/authorization/routes/api/role.js
+++ b/lib/modules/authorization/routes/api/role.js
@@ -167,13 +167,6 @@ exports.removeUsers = {
     }
 };
 
-// GET /permission
-exports.listPermissions = {
-    description: 'Lists all permissions in the system',
-    pre: [AuthCtrl.authorize(Resources.ROLE, Actions.LIST)],
-    handler: RoleCtrl.listPermissions
-};
-
 // POST /role/{id}/permissions
 exports.addPermission = {
     description: 'Add a permission to an existing role',

--- a/lib/modules/authorization/services/permission.js
+++ b/lib/modules/authorization/services/permission.js
@@ -1,0 +1,128 @@
+/**
+ * Permission Service
+ * @module
+ */
+const Hoek = require('hoek');
+const NSError = require('errors/nserror');
+const Repository = require('plugins/repository');
+const Action = require('utils/action');
+
+/**
+ * Counts the number of permissions
+ * @param {Object} [criteria] the search criteria
+ * @returns {Promise<number>} the number of permissions
+ */
+exports.count = async function(criteria = {}) {
+    return (await Repository.Permission.count({ ...criteria, relations: 'resource' })).count;
+};
+
+/**
+ * Retrieves all permissions
+ * @param {Object} [criteria] the search criteria
+ * @returns {Promise<Role[]>} all retrieved permissions
+ */
+exports.list = function(criteria) {
+    return Repository.Permission.findAll({ ...criteria, relations: 'resource' })
+        .omit(['resourceId'])
+        .eager('resource');
+};
+
+/**
+ * Retrieves a permission by its id
+ * @async
+ * @param {number} id the permission id
+ * @returns {Promise<Role>} the retrieved permission
+ */
+exports.findById = async function(id) {
+    const permission = await Repository.Permission.findOne(id)
+        .omit(['resourceId'])
+        .eager('resource');
+
+    if (!permission) {
+        throw NSError.RESOURCE_NOT_FOUND();
+    }
+
+    return permission;
+};
+
+/**
+ * Creates a permission
+ * @param {Permission} entity the permission to save
+ * @returns {Promise<Role>} the created permission
+ */
+exports.add = function(entity) {
+    if (!Action.isAction(entity.action)) {
+        throw NSError.RESOURCE_NOT_FOUND('Invalid action');
+    }
+
+    // transaction protects against duplicates caused by simultaneous add
+    return Repository.tx(
+        [Repository.Permission.model, Repository.Resource.model],
+        async (txPermissionRepository, txResourceRepository) => {
+            const resource = await txResourceRepository.query().findOne({ name: entity.resource });
+
+            if (!resource) {
+                throw NSError.RESOURCE_NOT_FOUND('Invalid resource name');
+            }
+
+            const permission = await txPermissionRepository
+                .query()
+                .findOne({ action: entity.action, resourceId: resource.id });
+
+            if (permission) {
+                throw NSError.RESOURCE_DUPLICATE();
+            }
+
+            return txPermissionRepository.add({
+                action: entity.action,
+                description: entity.description,
+                resourceId: resource.id
+            });
+        }
+    );
+};
+
+/**
+ * Removes a permission
+ * @param {number} id the permission id
+ * @returns {Promise} resolved if the transaction was committed with success
+ */
+exports.delete = function(id) {
+    return Repository.tx(Repository.Permission.model, async txPermissionRepository => {
+        const permission = await txPermissionRepository.findOne(id).eager('roles');
+
+        if (!permission) {
+            throw NSError.RESOURCE_NOT_FOUND();
+        }
+
+        if (permission.roles.length !== 0) {
+            throw NSError.RESOURCE_RELATION();
+        }
+
+        const count = await txPermissionRepository.remove(id);
+
+        if (count !== 1) {
+            throw NSError.RESOURCE_DELETE();
+        }
+    });
+};
+
+/**
+ * Updates an existing permission
+ * @param {number} id the id of the permission to update
+ * @param {Permission} entity the permission to update
+ * @returns {Promise<Resource>} the updated permission
+ */
+exports.update = function(id, entity) {
+    return Repository.tx(Repository.Permission.model, async txPermissionRepository => {
+        const permission = await txPermissionRepository.findOne(id);
+
+        if (!permission) {
+            throw NSError.RESOURCE_NOT_FOUND();
+        }
+
+        Hoek.merge(permission, Hoek.cloneWithShallow(entity, ['description']));
+
+        return txPermissionRepository.update(permission);
+    });
+};

--- a/lib/modules/authorization/services/role.js
+++ b/lib/modules/authorization/services/role.js
@@ -243,15 +243,6 @@ exports.removeUsers = function(id, userIds) {
 };
 
 /**
- * Retrieves all possible permissions
- * @param {(number|string|Object)} [criteria] search criteria
- * @returns {Promise<Resource[]>} all retrieved permissions
- */
-exports.listPermissions = function() {
-    return Repository.Resource.findAll().eager('permissions');
-};
-
-/**
  * Adds a permission to a role
  * @param {number} id the id of the role
  * @param {Action} action the permission action

--- a/lib/routes/api/index.js
+++ b/lib/routes/api/index.js
@@ -46,7 +46,8 @@ exports.endpoints = [
     { method: 'PUT', path: '/role/{id}/permissions', config: Role.updatePermissions },
 
     { method: 'GET', path: '/resource', config: Resource.list },
-    
+    { method: 'GET', path: '/resource/{name}', config: Resource.get},
+
     { method: 'GET', path: '/permission', config: Permission.list },
     { method: 'GET', path: '/permission/{id}', config: Permission.get },
     { method: 'POST', path: '/permission', config: Permission.create },

--- a/lib/routes/api/index.js
+++ b/lib/routes/api/index.js
@@ -12,6 +12,7 @@ const Register = require('modules/authorization/routes/api/register');
 const User = require('modules/authorization/routes/api/user');
 const Role = require('modules/authorization/routes/api/role');
 const Resource = require('modules/authorization/routes/api/resource');
+const Permission = require('modules/authorization/routes/api/permission');
 
 exports.endpoints = [
     { method: 'GET', path: '/version', config: Version.get },
@@ -35,8 +36,6 @@ exports.endpoints = [
     { method: 'DELETE', path: '/user/{id}', config: User.delete },
 
     { method: 'GET', path: '/role', config: Role.list },
-    { method: 'GET', path: '/resource', config: Resource.list },
-    { method: 'GET', path: '/permission', config: Role.listPermissions },
     { method: 'GET', path: '/role/{id}', config: Role.get },
     { method: 'POST', path: '/role', config: Role.create },
     { method: 'PUT', path: '/role/{id}', config: Role.update },
@@ -45,6 +44,14 @@ exports.endpoints = [
     { method: 'DELETE', path: '/role/{id}/users', config: Role.removeUsers },
     { method: 'POST', path: '/role/{id}/permissions', config: Role.addPermission },
     { method: 'PUT', path: '/role/{id}/permissions', config: Role.updatePermissions },
+
+    { method: 'GET', path: '/resource', config: Resource.list },
+    
+    { method: 'GET', path: '/permission', config: Permission.list },
+    { method: 'GET', path: '/permission/{id}', config: Permission.get },
+    { method: 'POST', path: '/permission', config: Permission.create },
+    { method: 'PUT', path: '/permission/{id}', config: Permission.update },
+    { method: 'DELETE', path: '/permission/{id}', config: Permission.delete },
 
     { method: 'GET', path: '/contact', config: Contacts.list },
     { method: 'GET', path: '/contact/{id}', config: Contacts.get },

--- a/test/modules/authorization/controllers/api/permission.js
+++ b/test/modules/authorization/controllers/api/permission.js
@@ -1,0 +1,449 @@
+const Hoek = require('hoek');
+const Lab = require('lab');
+const Sinon = require('sinon');
+const Hapi = require('hapi');
+const PermissionService = require('modules/authorization/services/permission');
+const PermissionCtrl = require('modules/authorization/controllers/api/permission');
+const Resources = require('enums/resources');
+const NSError = require('errors/nserror');
+
+const { beforeEach, describe, expect, it } = (exports.lab = Lab.script());
+
+describe('API Controller: permission', () => {
+    const permissions = [
+        {
+            id: 0,
+            action: 'read',
+            description: 'read user',
+            resourceId: 2
+        },
+        {
+            id: 1,
+            action: 'create',
+            description: 'create user',
+            resourceId: 4
+        }
+    ];
+
+    let server;
+
+    beforeEach(() => {
+        server = Hapi.server({ debug: { log: false, request: false } });
+    });
+
+    it('lists available permissions', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            listStub.restore();
+            countStub.restore();
+        };
+
+        // setup
+        const listStub = Sinon.stub(PermissionService, 'list');
+        const countStub = Sinon.stub(PermissionService, 'count');
+        const toolkitStub = Sinon.stub()
+            .withArgs(permissions, permissions.length)
+            .returns(permissions);
+
+        listStub.resolves(permissions);
+        countStub.resolves(permissions.length);
+
+        server.route({ method: 'GET', path: '/permission', handler: PermissionCtrl.list });
+        server.decorate('toolkit', 'paginate', toolkitStub);
+
+        // exercise
+        const response = await server.inject({
+            method: 'GET',
+            url: '/permission'
+        });
+
+        // validate
+        expect(listStub.calledOnce).to.be.true();
+        expect(countStub.calledOnce).to.be.true();
+        expect(toolkitStub.calledOnce).to.be.true();
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.statusMessage).to.equal('OK');
+        expect(response.result).to.equal(permissions);
+    });
+
+    it('lists available permissions with criteria', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            listStub.restore();
+            countStub.restore();
+        };
+
+        // setup
+        const fakeCriteria = { limit: '100' };
+        const listStub = Sinon.stub(PermissionService, 'list');
+        const countStub = Sinon.stub(PermissionService, 'count');
+        const toolkitStub = Sinon.stub()
+            .withArgs(permissions, permissions.length)
+            .returns(permissions);
+
+        listStub.withArgs(fakeCriteria).resolves(permissions);
+        countStub.withArgs(fakeCriteria).resolves(permissions.length);
+
+        server.route({ method: 'GET', path: '/permission', handler: PermissionCtrl.list });
+        server.decorate('toolkit', 'paginate', toolkitStub);
+
+        // exercise
+        const response = await server.inject({
+            method: 'GET',
+            url: '/permission?limit=100'
+        });
+
+        // validate
+        expect(listStub.calledOnce).to.be.true();
+        expect(countStub.calledOnce).to.be.true();
+        expect(toolkitStub.calledOnce).to.be.true();
+        expect(response.statusCode).to.equal(200);
+        expect(response.statusMessage).to.equal('OK');
+        expect(response.result).to.equal(permissions);
+    });
+
+    it('handles server errors while listing permissions', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            listStub.restore();
+            countStub.restore();
+        };
+
+        // setup
+        const listStub = Sinon.stub(PermissionService, 'list');
+        const countStub = Sinon.stub(PermissionService, 'count');
+
+        listStub.rejects(NSError.RESOURCE_FETCH());
+        countStub.resolves();
+
+        server.route({ method: 'GET', path: '/permission', handler: PermissionCtrl.list });
+
+        // exercise
+        const response = await server.inject({
+            method: 'GET',
+            url: '/permission'
+        });
+
+        // validate
+        expect(listStub.calledOnce).to.be.true();
+        expect(countStub.calledOnce).to.be.true();
+
+        expect(response.statusCode).to.equals(500);
+        expect(response.statusMessage).to.equals('Internal Server Error');
+        expect(response.result.message).to.equals('An internal server error occurred');
+    });
+
+    it('gets a permission', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            findByIdStub.restore();
+        };
+
+        // setup
+        const findByIdStub = Sinon.stub(PermissionService, 'findById');
+        findByIdStub.withArgs(1).resolves(permissions[1]);
+
+        server.route({ method: 'GET', path: '/permission/{id}', handler: PermissionCtrl.get });
+
+        // exercise
+        const response = await server.inject({
+            method: 'GET',
+            url: '/permission/1'
+        });
+
+        // validate
+        expect(findByIdStub.calledOnce).to.be.true();
+
+        expect(response.statusCode).to.equal(200);
+        expect(response.statusMessage).to.equal('OK');
+        expect(response.result).to.equal(permissions[1]);
+    });
+
+    it('handles getting of a non existing permission', async flags => {
+        // clean up
+        flags.onCleanup = function() {
+            findByIdStub.restore();
+        };
+
+        // setup
+        const findByIdStub = Sinon.stub(PermissionService, 'findById');
+        findByIdStub.rejects(NSError.RESOURCE_NOT_FOUND());
+
+        server.route({ method: 'GET', path: '/permission/{id}', handler: PermissionCtrl.get });
+
+        // exercise
+        const response = await server.inject({
+            method: 'GET',
+            url: '/permission/10'
+        });
+
+        // validate
+        expect(findByIdStub.calledOnce).to.be.true();
+
+        expect(response.statusCode).to.equal(404);
+        expect(response.statusMessage).to.equal('Not Found');
+        expect(response.result.message).to.equal(NSError.RESOURCE_NOT_FOUND().message);
+    });
+
+    it('handles server errors while getting a permission', async flags => {
+        // clean up
+        flags.onCleanup = function() {
+            findByIdStub.restore();
+        };
+
+        // setup
+        const findByIdStub = Sinon.stub(PermissionService, 'findById');
+        findByIdStub.rejects(NSError.RESOURCE_FETCH());
+
+        server.route({ method: 'GET', path: '/permission/{id}', handler: PermissionCtrl.get });
+
+        // exercise
+        const response = await server.inject({
+            method: 'GET',
+            url: '/permission/1'
+        });
+
+        // validate
+        expect(findByIdStub.calledOnce).to.be.true();
+
+        expect(response.statusCode).to.equal(500);
+        expect(response.statusMessage).to.equal('Internal Server Error');
+        expect(response.result.message).to.equal('An internal server error occurred');
+    });
+
+    it('creates a new permission', async flags => {
+        // clean up
+        flags.onCleanup = function() {
+            addStub.restore();
+        };
+
+        // setup
+        const fakeId = 2;
+        const entity = { action: 'delete', description: 'potato', resourceId: Resources.CONTACT };
+        const addStub = Sinon.stub(PermissionService, 'add');
+        addStub.withArgs(entity).resolves(Hoek.merge({ id: fakeId }, entity));
+
+        server.route({ method: 'POST', path: '/permission', handler: PermissionCtrl.create });
+
+        // exercise
+        const response = await server.inject({
+            method: 'POST',
+            url: '/permission',
+            payload: entity
+        });
+
+        // validate
+        expect(addStub.calledOnce).to.be.true();
+        expect(response.statusCode).to.equal(201);
+        expect(response.statusMessage).to.equal('Created');
+
+        expect(response.result.id).to.equal(fakeId);
+        expect(response.result.action).to.equal(entity.action);
+        expect(response.result.description).to.equal(entity.description);
+        expect(response.result.resourceId).to.equal(entity.resourceId);
+        expect(response.headers.location).to.equal(`/permission/${fakeId}`);
+    });
+
+    it('does not create a permission that already exists', async flags => {
+        // clean up
+        flags.onCleanup = function() {
+            addStub.restore();
+        };
+
+        // setup
+        const addStub = Sinon.stub(PermissionService, 'add');
+        addStub.rejects(NSError.RESOURCE_DUPLICATE());
+
+        server.route({ method: 'POST', path: '/permission', handler: PermissionCtrl.create });
+
+        // exercise
+        const response = await server.inject({
+            method: 'POST',
+            url: '/permission'
+        });
+
+        // validate
+        expect(addStub.calledOnce).to.be.true();
+
+        expect(response.statusCode).to.equal(409);
+        expect(response.statusMessage).to.equal('Conflict');
+        expect(response.result.message).to.equal(NSError.RESOURCE_DUPLICATE().message);
+    });
+
+    it('handles servers error while creating a permission', async flags => {
+        // clean up
+        flags.onCleanup = function() {
+            addStub.restore();
+        };
+
+        // setup
+        const addStub = Sinon.stub(PermissionService, 'add');
+        addStub.rejects(NSError.RESOURCE_INSERT());
+
+        server.route({ method: 'POST', path: '/permission', handler: PermissionCtrl.create });
+
+        // exercise
+        const response = await server.inject({
+            method: 'POST',
+            url: '/permission'
+        });
+
+        // validate
+        expect(addStub.calledOnce).to.be.true();
+
+        expect(response.statusCode).to.equal(500);
+        expect(response.statusMessage).to.equal('Internal Server Error');
+        expect(response.result.message).to.equal('An internal server error occurred');
+    });
+
+    it('deletes an existing permission', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            deleteStub.restore();
+        };
+
+        // setup
+        const deleteStub = Sinon.stub(PermissionService, 'delete');
+        deleteStub.withArgs(1).resolves();
+
+        server.route({
+            method: 'DELETE',
+            path: '/permission/{id}',
+            handler: PermissionCtrl.delete
+        });
+
+        // exercise
+        const response = await server.inject({
+            method: 'DELETE',
+            url: '/permission/1'
+        });
+
+        // validate
+        expect(deleteStub.calledOnce).to.be.true();
+        expect(response.statusCode).to.equal(204);
+        expect(response.statusMessage).to.equal('No Content');
+    });
+
+    it('handles deleting a permission that does not exist', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            deleteStub.restore();
+        };
+
+        // setup
+        const deleteStub = Sinon.stub(PermissionService, 'delete');
+        deleteStub.rejects(NSError.RESOURCE_NOT_FOUND());
+
+        server.route({
+            method: 'DELETE',
+            path: '/permission/{id}',
+            handler: PermissionCtrl.delete
+        });
+
+        // exercise
+        const response = await server.inject({
+            method: 'DELETE',
+            url: '/permission/1'
+        });
+
+        // validate
+        expect(deleteStub.calledOnce).to.be.true();
+        expect(response.statusCode).to.equal(404);
+        expect(response.statusMessage).to.equal('Not Found');
+        expect(response.result.message).to.equal(NSError.RESOURCE_NOT_FOUND().message);
+    });
+
+    it('handles server errors while deleting a permission', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            deleteStub.restore();
+        };
+
+        // setup
+        const deleteStub = Sinon.stub(PermissionService, 'delete');
+        deleteStub.rejects(NSError.RESOURCE_DELETE());
+
+        server.route({
+            method: 'DELETE',
+            path: '/permission/{id}',
+            handler: PermissionCtrl.delete
+        });
+
+        // exercise
+        const response = await server.inject({
+            method: 'DELETE',
+            url: '/permission/1'
+        });
+
+        // validate
+        expect(deleteStub.calledOnce).to.be.true();
+        expect(response.statusCode).to.equal(500);
+        expect(response.statusMessage).to.equal('Internal Server Error');
+        expect(response.result.message).to.equal('An internal server error occurred');
+    });
+
+    it('updates a permission', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            updateStub.restore();
+        };
+
+        // setup
+        const fakePermission = { id: 1, action: 'create', resourceId: 10 };
+        const entity = { description: 'potato' };
+        const updateStub = Sinon.stub(PermissionService, 'update');
+        updateStub.withArgs(fakePermission.id, entity).resolves(Hoek.merge(fakePermission, entity));
+
+        server.route({
+            method: 'PUT',
+            path: '/permission/{id}',
+            handler: PermissionCtrl.update
+        });
+
+        // exercise
+        const response = await server.inject({
+            method: 'PUT',
+            url: `/permission/${fakePermission.id}`,
+            payload: entity
+        });
+
+        // validate
+        expect(updateStub.calledOnce).to.be.true();
+        expect(response.statusCode).to.equal(200);
+        expect(response.statusMessage).to.equal('OK');
+        expect(response.result.id).to.equal(fakePermission.id);
+        expect(response.result.action).to.equal(fakePermission.action);
+        expect(response.result.resourceId).to.equal(fakePermission.resourceId);
+        expect(response.result.description).to.equal(entity.description);
+    });
+
+    it('handles server errors while updating a permission', async flags => {
+        // cleanup
+        flags.onCleanup = function() {
+            updateStub.restore();
+        };
+
+        // setup
+        const updateStub = Sinon.stub(PermissionService, 'update');
+        updateStub.rejects(NSError.RESOURCE_UPDATE());
+
+        server.route({
+            method: 'PUT',
+            path: '/permission/{id}',
+            handler: PermissionCtrl.update
+        });
+
+        // exercise
+        const response = await server.inject({
+            method: 'PUT',
+            url: '/permission/1'
+        });
+
+        // validate
+        expect(updateStub.calledOnce).to.be.true();
+        expect(response.statusCode).to.equal(500);
+        expect(response.statusMessage).to.equal('Internal Server Error');
+        expect(response.result.message).to.equal('An internal server error occurred');
+    });
+});

--- a/test/modules/authorization/controllers/api/role.js
+++ b/test/modules/authorization/controllers/api/role.js
@@ -27,17 +27,6 @@ describe('API Controller: role', () => {
         }
     ];
 
-    const permissions = [
-        {
-            name: 'bootcamp',
-            permissions: [{ id: 1, action: 'create' }, { id: 2, action: 'delete' }]
-        },
-        {
-            name: 'documents',
-            permissions: [{ id: 1, action: 'create' }, { id: 2, action: 'delete' }]
-        }
-    ];
-
     let server;
 
     beforeEach(() => {
@@ -135,55 +124,6 @@ describe('API Controller: role', () => {
         // validate
         expect(listStub.calledOnce).to.be.true();
         expect(countStub.calledOnce).to.be.true();
-        expect(response.statusCode).to.equals(500);
-        expect(response.statusMessage).to.equals('Internal Server Error');
-        expect(response.result.message).to.equal('An internal server error occurred');
-    });
-
-    it('lists available permissions', async flags => {
-        // cleanup
-        flags.onCleanup = function() {
-            listStub.restore();
-        };
-
-        // setup
-        const listStub = Sinon.stub(RoleService, 'listPermissions').resolves(permissions);
-
-        server.route({ method: 'GET', path: '/permission', handler: RoleCtrl.listPermissions });
-
-        // exercise
-        const response = await server.inject({
-            method: 'GET',
-            url: '/permission'
-        });
-
-        // validate
-        expect(listStub.calledOnce).to.be.true();
-        expect(response.statusCode).to.equal(200);
-        expect(response.statusMessage).to.equal('OK');
-        expect(response.result).to.equal(permissions);
-    });
-
-    it('handles server errors while listing permissions', async flags => {
-        // cleanup
-        flags.onCleanup = function() {
-            listStub.restore();
-        };
-
-        // setup
-        const listStub = Sinon.stub(RoleService, 'listPermissions').rejects(
-            NSError.RESOURCE_FETCH()
-        );
-        server.route({ method: 'GET', path: '/permissions', handler: RoleCtrl.listPermissions });
-
-        // exercise
-        const response = await server.inject({
-            method: 'GET',
-            url: '/permissions'
-        });
-
-        // validate
-        expect(listStub.calledOnce).to.be.true();
         expect(response.statusCode).to.equals(500);
         expect(response.statusMessage).to.equals('Internal Server Error');
         expect(response.result.message).to.equal('An internal server error occurred');

--- a/test/modules/authorization/services/contacts.js
+++ b/test/modules/authorization/services/contacts.js
@@ -22,9 +22,7 @@ describe('Service: contacts', () => {
     let knex;
 
     beforeEach(async () => {
-        /*jshint -W064 */
-        knex = Knex(KnexConfig.testing); // eslint-disable-line
-        /*jshint -W064 */
+        knex = Knex(KnexConfig.testing);
 
         await knex.migrate.latest();
         await knex.seed.run();
@@ -208,16 +206,23 @@ describe('Service: contacts', () => {
         };
 
         // setup
+        const id = 2;
         const txSpy = Sinon.spy(Repository, 'tx');
 
         // exercise
-        const result = await ContactsService.delete(2);
+        const result = await ContactsService.delete(id);
 
         // validate
         expect(txSpy.calledOnce).to.be.true();
         expect(txSpy.args[0].length).to.equals(2);
         expect(txSpy.args[0][0]).to.equals(ContactModel);
         expect(result).to.not.exist();
+
+        expect(
+            await knex('contacts')
+                .where('id', id)
+                .first()
+        ).to.not.exist();
     });
 
     it('handles deleting a non existing contact', async () => {

--- a/test/modules/authorization/services/permission.js
+++ b/test/modules/authorization/services/permission.js
@@ -1,0 +1,431 @@
+const Lab = require('lab');
+const Hapi = require('hapi');
+const Knex = require('knex');
+const Sinon = require('sinon');
+const Objection = require('objection');
+const KnexConfig = require('knexfile');
+const PermissionService = require('modules/authorization/services/permission');
+const Repository = require('plugins/repository');
+const PermissionModel = require('models/permission');
+const ResourceModel = require('models/resource');
+const NSError = require('errors/nserror');
+const Logger = require('test/fixtures/logger-plugin');
+const Resources = require('enums/resources');
+
+const { afterEach, beforeEach, describe, expect, it } = (exports.lab = Lab.script());
+
+describe('Service: permission', function() {
+    let txSpy;
+    let knex;
+
+    beforeEach(async () => {
+        knex = Knex(KnexConfig.testing);
+
+        await knex.migrate.latest();
+        await knex.seed.run();
+
+        Objection.Model.knex(knex);
+
+        const server = Hapi.server();
+        server.register(Logger);
+        server.register({
+            plugin: Repository,
+            options: {
+                models: ['permission', 'resource']
+            }
+        });
+
+        txSpy = Sinon.spy(Repository, 'tx');
+    });
+
+    afterEach(() => {
+        if (txSpy) {
+            txSpy.restore();
+        }
+    });
+
+    it('counts permissions', async () => {
+        // exercise
+        const result = await PermissionService.count();
+
+        // validate
+        expect(result).to.equal(10);
+    });
+
+    it('counts permissions with a limit criteria', async () => {
+        // setup
+        const criteria = { limit: 1 };
+
+        // exercise
+        const result = await PermissionService.count(criteria);
+
+        // validate
+        expect(result).to.equal(10);
+    });
+
+    it('counts permissions with a search criteria', async () => {
+        // setup
+        const criteria = { search: 'Should not change' };
+
+        // exercise
+        const result = await PermissionService.count(criteria);
+
+        // validate
+        expect(result).to.equal(2);
+    });
+
+    it('counts permissions with a search criteria for the related permission resource', async () => {
+        // setup
+        const criteria = { search: 'user' };
+
+        // exercise
+        const result = await PermissionService.count(criteria);
+
+        // validate
+        expect(result).to.equal(4);
+    });
+
+    it('counts permissions with limit and search criteria for the related permission resource', async () => {
+        // setup
+        const criteria = { search: 'user', limit: 1 };
+
+        // exercise
+        const result = await PermissionService.count(criteria);
+
+        // validate
+        expect(result).to.equal(4);
+    });
+
+    it('lists permissions', async () => {
+        // exercise
+        const results = await PermissionService.list();
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(10);
+        expect(results.resource).to.not.exist();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id).to.exist();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('lists permissions with limit criteria', async () => {
+        // setup
+        const criteria = { limit: 2 };
+
+        // exercise
+        const results = await PermissionService.list(criteria);
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(2);
+        expect(results.resource).to.not.exist();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id).to.exist();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('lists permissions with search criteria', async () => {
+        // setup
+        const criteria = { search: Resources.USER };
+
+        // exercise
+        const results = await PermissionService.list(criteria);
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(4);
+        expect(results.resource).to.not.exist();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id).to.exist();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('lists permissions with offset', async () => {
+        // setup
+        const criteria = { page: 2, limit: 2 };
+
+        // exercise
+        const results = await PermissionService.list(criteria);
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(2);
+        expect(results.resource).to.not.exist();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id > 2).to.be.true();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('lists permissions ordered by column', async () => {
+        // setup
+        const criteria = { sort: 'description' };
+
+        // exercise
+        const results = await PermissionService.list(criteria);
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(10);
+        expect(results.resource).to.not.exist();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id).to.exist();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('lists permissions by column descending', async () => {
+        // setup
+        const criteria = { sort: '-id' };
+
+        // exercise
+        const results = await PermissionService.list(criteria);
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(10);
+        expect(results.resource).to.not.exist();
+        expect(results[0].id > results[1].id).to.be.true();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id).to.exist();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('lists permissions by column descending and limit criteria', async () => {
+        // setup
+        const criteria = { sort: '-id', limit: 2 };
+
+        // exercise
+        const results = await PermissionService.list(criteria);
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(2);
+        expect(results.resource).to.not.exist();
+        expect(results[0].id > results[1].id).to.be.true();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id).to.exist();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('lists permissions by column descending, limit and search criteria for the related permission resource', async () => {
+        // setup
+        const criteria = { sort: '-id', limit: 2, search: 'user' };
+
+        // exercise
+        const results = await PermissionService.list(criteria);
+
+        // validate
+        expect(results).to.be.an.array();
+        expect(results.length).to.equal(2);
+        expect(results.resource).to.not.exist();
+        expect(results[0].id > results[1].id).to.be.true();
+
+        results.forEach(permission => {
+            expect(permission).to.be.instanceof(PermissionModel);
+            expect(permission.id).to.exist();
+            expect(permission.action).to.be.a.string();
+            expect(permission.resource).to.be.an.instanceof(ResourceModel);
+            expect(permission.description).to.satisfy(
+                value => value === null || typeof value === 'string'
+            );
+        });
+    });
+
+    it('gets valid permission by id', async () => {
+        // setup
+        const id = 9;
+        const permission = {
+            id: 9,
+            action: 'read',
+            description: 'Should not change'
+        };
+
+        // exercise
+        const result = await PermissionService.findById(id);
+
+        // validate
+        expect(result).to.be.an.object();
+        expect(result).to.be.instanceof(PermissionModel);
+
+        expect(result.id).to.equal(permission.id);
+        expect(result.action).to.equal(permission.action);
+        expect(result.description).to.equal(permission.description);
+        expect(result.resource).to.be.an.instanceof(ResourceModel);
+    });
+
+    it('handles getting a permission with an invalid id', async () => {
+        // exercise and validade
+        await expect(PermissionService.findById(666)).to.reject(
+            Error,
+            NSError.RESOURCE_NOT_FOUND().message
+        );
+    });
+
+    it('adds a new permission', async () => {
+        // setup
+        const permission = {
+            id: 11,
+            action: 'delete',
+            description: 'potato',
+            resource: 'noroles'
+        };
+
+        // exercise
+        const result = await PermissionService.add(permission);
+
+        // validate
+        expect(txSpy.calledOnce).to.be.true();
+        expect(txSpy.args[0].length).to.equal(2);
+
+        expect(txSpy.args[0][0].indexOf(PermissionModel)).to.not.equal(-1);
+        expect(txSpy.args[0][0].indexOf(ResourceModel)).to.not.equal(-1);
+
+        expect(result).to.be.an.instanceof(PermissionModel);
+        expect(result.id).to.equal(permission.id);
+        expect(result.action).to.equal(permission.action);
+        expect(result.description).to.equal(permission.description);
+        expect(result.resourceId).to.equal(4);
+    });
+
+    it('does not add a permission with the same action for the same resource', async () => {
+        // setup
+        const entity = {
+            action: 'read',
+            description: 'potato',
+            resource: 'user'
+        };
+
+        // exercise and validate
+        await expect(PermissionService.add(entity)).to.reject(
+            Error,
+            NSError.RESOURCE_DUPLICATE().message
+        );
+    });
+
+    it('does not add a permission for an invalid resource', async () => {
+        // setup
+        const entity = {
+            action: 'delete',
+            description: 'potato',
+            resource: 'potato'
+        };
+
+        // exercise and validate
+        await expect(PermissionService.add(entity)).to.reject(Error, 'Invalid resource name');
+    });
+
+    it('does not add a permission with an invalid action', async () => {
+        // exercise and validate
+        expect(() => PermissionService.add({ action: 'xpto' })).to.throw(Error, 'Invalid action');
+    });
+
+    it('deletes an existing permission', async () => {
+        // setup
+        const id = 9;
+
+        // exercise
+        const result = await PermissionService.delete(id);
+
+        //validate
+        expect(txSpy.calledOnce).to.be.true();
+        expect(txSpy.args[0].length).to.equal(2);
+        expect(txSpy.args[0][0]).to.equal(PermissionModel);
+        expect(result).to.not.exist();
+
+        expect(
+            await knex('permissions')
+                .where('id', id)
+                .first()
+        ).to.not.exist();
+    });
+
+    it('does not delete a non existing permission', async () => {
+        // exercise and validate
+        await expect(PermissionService.delete(999)).to.reject(
+            Error,
+            NSError.RESOURCE_NOT_FOUND().message
+        );
+    });
+
+    it('does not delete a permission associated with roles', async () => {
+        // exercise and validate
+        await expect(PermissionService.delete(1)).to.reject(
+            Error,
+            NSError.RESOURCE_RELATION().message
+        );
+    });
+
+    it('updates an existing permission', async () => {
+        // setup
+        const id = 9;
+        const permission = { description: 'potato' };
+
+        // exercise
+        const result = await PermissionService.update(id, permission);
+
+        // validate
+        expect(txSpy.calledOnce).to.be.true();
+        expect(txSpy.args[0].length).to.equal(2);
+        expect(txSpy.args[0][0]).to.equal(PermissionModel);
+        expect(result).to.be.instanceof(PermissionModel);
+        expect(result.id).to.equal(id);
+        expect(result.description).to.equal(permission.description);
+    });
+
+    it('handles updating a non existing permission', async () => {
+        // exercise and validate
+        await expect(PermissionService.update(999)).to.reject(
+            Error,
+            NSError.RESOURCE_NOT_FOUND().message
+        );
+    });
+});

--- a/test/modules/authorization/services/resource.js
+++ b/test/modules/authorization/services/resource.js
@@ -15,11 +15,10 @@ const { afterEach, beforeEach, describe, expect, it } = (exports.lab = Lab.scrip
 
 describe('Service: resource', () => {
     let txSpy;
+    let knex;
 
     beforeEach(async () => {
-        /*jshint -W064 */
-        const knex = Knex(KnexConfig.testing); // eslint-disable-line
-        /*jshint -W064 */
+        knex = Knex(KnexConfig.testing);
 
         await knex.migrate.latest();
         await knex.seed.run();
@@ -44,7 +43,7 @@ describe('Service: resource', () => {
         const result = await ResourceService.count();
 
         // validate
-        expect(result).to.equals(4);
+        expect(result).to.equals(7);
     });
 
     it('counts resources with search criteria', async () => {
@@ -64,7 +63,7 @@ describe('Service: resource', () => {
 
         // validate
         expect(results).to.be.an.array();
-        expect(results.length).to.equals(4);
+        expect(results.length).to.equals(7);
         results.forEach(resource => {
             expect(resource).to.be.instanceof(ResourceModel);
             expect(resource.name).to.be.a.string();
@@ -144,7 +143,7 @@ describe('Service: resource', () => {
 
         // validate
         expect(results).to.be.an.array();
-        expect(results.length).to.equals(4);
+        expect(results.length).to.equals(7);
         results.forEach(resource => {
             expect(resource).to.be.instanceof(ResourceModel);
             expect(resource.id).to.exist();
@@ -162,7 +161,7 @@ describe('Service: resource', () => {
         // exercise
         const results = await ResourceService.list(criteria);
         expect(results).to.be.an.array();
-        expect(results.length).to.equals(4);
+        expect(results.length).to.equals(7);
         expect(results[0].id > results[1].id).to.be.true();
         results.forEach(resource => {
             expect(resource).to.be.instanceof(ResourceModel);
@@ -246,12 +245,21 @@ describe('Service: resource', () => {
     });
 
     it('deletes an existing resource', async () => {
+        // setup
+        const id = 3;
+
         // exercise
-        const result = await ResourceService.delete(3);
+        const result = await ResourceService.delete(id);
 
         // validate
         expect(txSpy.calledOnce).to.be.true();
         expect(result).to.not.exists();
+
+        expect(
+            await knex('resources')
+                .where('id', id)
+                .first()
+        ).to.not.exist();
     });
 
     it('handles deleting a non existing resource', async () => {

--- a/test/modules/authorization/services/role.js
+++ b/test/modules/authorization/services/role.js
@@ -20,9 +20,7 @@ describe('Service: role', function() {
     let knex;
 
     beforeEach(async () => {
-        /*jshint -W064 */
-        knex = Knex(KnexConfig.testing); // eslint-disable-line
-        /*jshint -W064 */
+        knex = Knex(KnexConfig.testing);
 
         await knex.migrate.latest();
         await knex.seed.run();
@@ -168,25 +166,6 @@ describe('Service: role', function() {
         });
     });
 
-    it('lists permissions', async () => {
-        // exercise
-        const results = await RoleService.listPermissions();
-
-        // validate
-        expect(results).to.be.an.array();
-        expect(results.length).to.equals(4);
-        results.forEach(resource => {
-            expect(resource).to.be.instanceof(ResourceModel);
-            expect(resource.name).to.be.a.string();
-            expect(resource.permissions).to.be.an.array();
-            resource.permissions.forEach(permission => {
-                expect(permission).to.be.instanceof(PermissionModel);
-                expect(permission.id).to.be.a.number();
-                expect(permission.action).to.be.a.string();
-            });
-        });
-    });
-
     it('gets valid role by id', async () => {
         // setup
         const id = 2;
@@ -271,13 +250,22 @@ describe('Service: role', function() {
     });
 
     it('deletes an existing role', async () => {
+        // setup
+        const id = 4;
+
         // exercise
-        const result = await RoleService.delete(4);
+        const result = await RoleService.delete(id);
 
         expect(txSpy.calledOnce).to.be.true();
         expect(txSpy.args[0].length).to.equals(2);
         expect(txSpy.args[0][0]).to.equals(RoleModel);
         expect(result).to.not.exists();
+
+        expect(
+            await knex('roles')
+                .where('id', id)
+                .first()
+        ).to.not.exist();
     });
 
     it('does not delete a non existing role', async () => {
@@ -470,7 +458,7 @@ describe('Service: role', function() {
         // setup
         const roleId = 1;
         const resource = 'test';
-        const permission = { id: 10, action: 'create', description: 'create test' };
+        const permission = { id: 11, action: 'create', description: 'create test' };
 
         // exercise
         const result = await RoleService.addPermission(

--- a/test/modules/authorization/services/user.js
+++ b/test/modules/authorization/services/user.js
@@ -21,11 +21,10 @@ const { afterEach, beforeEach, describe, expect, it } = (exports.lab = Lab.scrip
 describe('Service: user', () => {
     let cryptStub;
     let txSpy;
+    let knex;
 
     beforeEach(async () => {
-        /*jshint -W064 */
-        const knex = Knex(KnexConfig.testing); // eslint-disable-line
-        /*jshint -W064 */
+        knex = Knex(KnexConfig.testing);
 
         await knex.migrate.latest();
         await knex.seed.run();
@@ -738,14 +737,23 @@ describe('Service: user', () => {
     });
 
     it('deletes an existing user', async () => {
+        // setup
+        const id = 3;
+
         // exercise
-        const result = await UserService.delete(3);
+        const result = await UserService.delete(id);
 
         // validate
         expect(txSpy.calledOnce).to.be.true();
         expect(txSpy.args[0].length).to.equals(2);
         expect(txSpy.args[0][0]).to.equals(UserModel);
         expect(result).to.not.exist();
+
+        expect(
+            await knex('users')
+                .where('id', id)
+                .first()
+        ).to.not.exist();
     });
 
     it('handles deleting a non existing user', async () => {

--- a/test/modules/authorization/services/user.js
+++ b/test/modules/authorization/services/user.js
@@ -250,11 +250,7 @@ describe('Service: user', () => {
             expect(user.username).to.be.a.string();
             expect(user.email).to.be.a.string();
             expect(user.password).to.not.exist();
-            expect(user.active).to.satisfy(
-                value =>
-                    // accommodate boolean in both sqlite and postgres
-                    value === true || value === 1
-            );
+            expect(user.active).to.equal(true);
         });
     });
 
@@ -276,11 +272,7 @@ describe('Service: user', () => {
             expect(user.username).to.be.a.string();
             expect(user.email).to.be.a.string();
             expect(user.password).to.not.exist();
-            expect(user.active).to.satisfy(
-                value =>
-                    // accommodate boolean in both sqlite and postgres
-                    value === true || value === 1
-            );
+            expect(user.active).to.equal(true);
         });
     });
 
@@ -302,11 +294,7 @@ describe('Service: user', () => {
             expect(user.username).to.be.a.string();
             expect(user.email).to.be.a.string();
             expect(user.password).to.not.exist();
-            expect(user.active).to.satisfy(
-                value =>
-                    // accommodate boolean in both sqlite and postgres
-                    value === true || value === 1
-            );
+            expect(user.active).to.equal(true);
         });
     });
 
@@ -615,11 +603,7 @@ describe('Service: user', () => {
         expect(result.email).to.equals(user.email);
         expect(result.avatar).to.equals(user.avatar);
         expect(result.password).to.equals(fakeHash);
-        expect(result.active).to.satisfy(
-            value =>
-                // accommodate boolean in both sqlite and postgres
-                value === true || value === 1
-        );
+        expect(result.active).to.equal(true);
     });
 
     it('updates an existing user without updating the username', async () => {
@@ -638,11 +622,7 @@ describe('Service: user', () => {
         expect(result.id).to.equals(id);
         expect(result.email).to.equals(user.email);
         expect(result.password).to.exists();
-        expect(result.active).to.satisfy(
-            value =>
-                // accommodate boolean in both sqlite and postgres
-                value === true || value === 1
-        );
+        expect(result.active).to.equal(true);
     });
 
     it('updates an existing user with same username and id as request parameters string', async () => {
@@ -708,14 +688,10 @@ describe('Service: user', () => {
         expect(result.name).to.equals(user.name);
         expect(result.email).to.equals(user.email);
         expect(result.password).to.equals(fakeHash);
-        expect(result.active).to.satisfy(
-            value =>
-                // accommodate boolean in both sqlite and postgres
-                value === true || value === 1
-        );
+        expect(result.active).to.equal(true);
     });
 
-    it('handles updating a non existing user', async () => {
+    it('handle updating a non existing user', async () => {
         await expect(UserService.update(900, {})).to.reject(
             Error,
             NSError.RESOURCE_NOT_FOUND().message


### PR DESCRIPTION
This pull request attemps to:

- Add permission routes, controller and service;
- Update development, staging and testing seeds;
- Fix service delete tests that were not checking if the entry was deleted;
- Remove unnecessary boolean handling in user service tests.

